### PR TITLE
Add new client: 一封传话聚合推送, 支持微信公众号、企业微信应用、企业微信群、钉钉群、飞书群、邮箱等, 一次调用多端推送。

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -2,7 +2,7 @@
 
 [简体中文](README.md) | [ENGLISH](README-EN.md)
 
-> Push notification sdk(Bark、Chanify、DingTalk、Discord、Email、FeiShu、Gitter、Google Chat、iGot、Logger、Mattermost、Microsoft Teams、Now Push、Ntfy、PushBack、Push、PushDeer、Pushover、PushPlus、QQ Channel Bot、Rocket Chat、ServerChan、Showdoc Push、Slack、Telegram、Webhook、WeWork、XiZhi、Zulip).
+> Push notification sdk(Bark、Chanify、DingTalk、Discord、Email、FeiShu、Gitter、Google Chat、iGot、Logger、Mattermost、Microsoft Teams、Now Push、Ntfy、PushBack、Push、PushDeer、Pushover、PushPlus、QQ Channel Bot、Rocket Chat、ServerChan、Showdoc Push、Slack、Telegram、Webhook、WeWork、XiZhi、Zulip、一封传话聚合推送).
 
 [![Tests](https://github.com/guanguans/notify/workflows/Tests/badge.svg)](https://github.com/guanguans/notify/actions)
 [![Check & fix styling](https://github.com/guanguans/notify/workflows/Check%20&%20fix%20styling/badge.svg)](https://github.com/guanguans/notify/actions)
@@ -47,6 +47,7 @@
 * [WeWork](https://open.work.weixin.qq.com/api/doc/90000/90136/91770)
 * [XiZhi](https://xz.qqoq.net/#/index)
 * [Zulip](https://zulip.com/api/send-message)
+* [一封传话聚合推送](https://www.phprm.com/push/h5/)
 
 ## Requirement
 
@@ -1004,6 +1005,20 @@ Factory::zulip()
         'topic' => 'bug',
         //'queue_id' => '1593114627:0',
         //'local_id' => '100.01',
+    ]))
+    ->send();
+```
+</details>
+
+<details>
+<summary><b>一封传话聚合推送</b></summary>
+
+```php
+Factory::yiFengChuanHua()
+    ->setToken('204dd77ce4a6f221')
+    ->setMessage(new \Guanguans\Notify\Messages\YiFengChuanHuaMessage([
+        'head' => 'This is title.',
+        'body' => 'This is content.',
     ]))
     ->send();
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [简体中文](README.md) | [ENGLISH](README-EN.md)
 
-> 推送通知 sdk(Bark、Chanify、钉钉群机器人、Discord、邮件、飞书群机器人、Gitter、Google Chat、iGot、Logger、Mattermost、Microsoft Teams、Now Push、Ntfy、PushBack、Push、PushDeer、Pushover、PushPlus、QQ 频道机器人、Rocket Chat、Server 酱、Showdoc Push、Slack、Telegram、Webhook、企业微信群机器人、息知、Zulip)。
+> 推送通知 sdk(Bark、Chanify、钉钉群机器人、Discord、邮件、飞书群机器人、Gitter、Google Chat、iGot、Logger、Mattermost、Microsoft Teams、Now Push、Ntfy、PushBack、Push、PushDeer、Pushover、PushPlus、QQ 频道机器人、Rocket Chat、Server 酱、Showdoc Push、Slack、Telegram、Webhook、企业微信群机器人、息知、Zulip、一封传话聚合推送)。
 
 [![Tests](https://github.com/guanguans/notify/workflows/Tests/badge.svg)](https://github.com/guanguans/notify/actions)
 [![Check & fix styling](https://github.com/guanguans/notify/workflows/Check%20&%20fix%20styling/badge.svg)](https://github.com/guanguans/notify/actions)
@@ -47,6 +47,7 @@
 * [企业微信群机器人](https://open.work.weixin.qq.com/api/doc/90000/90136/91770)
 * [息知](https://xz.qqoq.net/#/index)
 * [Zulip](https://zulip.com/api/send-message)
+* [一封传话聚合推送](https://www.phprm.com/push/h5/)
 
 ## 环境要求
 
@@ -1004,6 +1005,20 @@ Factory::zulip()
         'topic' => 'bug',
         //'queue_id' => '1593114627:0',
         //'local_id' => '100.01',
+    ]))
+    ->send();
+```
+</details>
+
+<details>
+<summary><b>一封传话聚合推送</b></summary>
+
+```php
+Factory::yiFengChuanHua()
+    ->setToken('204dd77ce4a6f221')
+    ->setMessage(new \Guanguans\Notify\Messages\YiFengChuanHuaMessage([
+        'head' => 'This is title.',
+        'body' => 'This is content.',
     ]))
     ->send();
 ```

--- a/src/Clients/YiFengChuanHuaClient.php
+++ b/src/Clients/YiFengChuanHuaClient.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @see http://push.phprm.com/api.html
+ *
+ * ```
+ * // send a get.
+ * curl --location --request GET 'https://www.phprm.com/services/push/trigger/{{token}}?head=title&body=content' \
+ *
+ * // send a post.
+ * curl --location --request POST 'https://www.phprm.com/services/push/trigger/{{token}}' \
+ * --header 'Content-Type: application/json' \
+ * --data-raw '{"head":"This is title.","body":"This is content."}'
+ * ```
+ * mobile manage url: https://www.phprm.com/push/h5/
+ */
+namespace Guanguans\Notify\Clients;
+
+class YiFengChuanHuaClient extends Client
+{
+
+    public const REQUEST_URL_TEMPLATE = 'https://www.phprm.com/services/push/trigger/%s';
+
+    public $requestMethod = 'postJson';
+
+    public function getRequestUrl(): string
+    {
+        return sprintf(static::REQUEST_URL_TEMPLATE, $this->getToken());
+    }
+
+    public function setRequestMethod(string $requestMethod)
+    {
+        $this->requestMethod = $requestMethod;
+
+        return $this;
+    }
+}

--- a/src/Messages/YifengChuanHuaMessage.php
+++ b/src/Messages/YifengChuanHuaMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the guanguans/notify.
+ *
+ * (c) guanguans <ityaozm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled.
+ */
+
+namespace Guanguans\Notify\Messages;
+
+class YiFengChuanHuaMessage extends Message
+{
+    /**
+     * @var string[]
+     */
+    protected $defined = [
+        'head',
+        'body',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected $required = [
+        'head',
+    ];
+
+}

--- a/tests/Feature/YiFengChuanHuaTest.php
+++ b/tests/Feature/YiFengChuanHuaTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the guanguans/notify.
+ *
+ * (c) guanguans <ityaozm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled.
+ */
+
+namespace Guanguans\Notify\Tests\Feature;
+
+use Guanguans\Notify\Factory;
+use Guanguans\Notify\Tests\TestCase;
+
+class YiFengChuanHuaTest extends TestCase
+{
+    public function testYiFengChuanHua()
+    {
+        // $this->markTestSkipped(__CLASS__.' is skipped.');
+
+        $ret = Factory::yiFengChuanHua()
+            ->setToken('204dd77ce4a6f221')
+            ->setMessage(new \Guanguans\Notify\Messages\YiFengChuanHuaMessage([
+                'head' => 'This is title.',
+                'body' => 'This is content.',
+            ]))
+            ->send();
+        $this->assertEquals(0, $ret['code']);
+    }
+
+}


### PR DESCRIPTION
新增【一封传话】聚合推送客户端，支持调用一次API, 多人多app同时收到推送内容。